### PR TITLE
Astronomical length units created and alias provided

### DIFF
--- a/include/boost/astronomy/units/length.hpp
+++ b/include/boost/astronomy/units/length.hpp
@@ -1,0 +1,67 @@
+#ifndef BOOST_ASTRONOMY_UNITS_UNITS_HPP
+#define BOOST_ASTRONOMY_UNITS_UNITS_HPP
+
+#include <boost/units/quantity.hpp>
+#include <boost/units/static_constant.hpp>
+#include <boost/units/base_units/astronomical/astronomical_unit.hpp>
+#include <boost/units/base_units/astronomical/light_day.hpp>
+#include <boost/units/base_units/astronomical/light_hour.hpp>
+#include <boost/units/base_units/astronomical/light_minute.hpp>
+#include <boost/units/base_units/astronomical/light_second.hpp>
+#include <boost/units/base_units/astronomical/light_year.hpp>
+#include <boost/units/base_units/astronomical/parsec.hpp>
+#include <boost/units/systems/si/length.hpp>
+#include <boost/units/systems/cgs/length.hpp>
+
+
+namespace boost { namespace astronomy { namespace units {
+
+namespace bu = boost::units;
+namespace bua = boost::units::astronomical;
+
+typedef bua::astronomical_unit_base_unit::unit_type length_astronomical_unit;
+BOOST_UNITS_STATIC_CONSTANT(astronomical_unit, length_astronomical_unit);
+BOOST_UNITS_STATIC_CONSTANT(astronomical_units, length_astronomical_unit);
+
+typedef bua::light_day_base_unit::unit_type length_light_day;
+BOOST_UNITS_STATIC_CONSTANT(light_day, length_light_day);
+BOOST_UNITS_STATIC_CONSTANT(light_days, length_light_day);
+
+typedef bua::light_hour_base_unit::unit_type length_light_hour;
+BOOST_UNITS_STATIC_CONSTANT(light_hour, length_light_hour);
+BOOST_UNITS_STATIC_CONSTANT(light_hours, length_light_hour);
+
+typedef bua::light_minute_base_unit::unit_type length_light_minute;
+BOOST_UNITS_STATIC_CONSTANT(light_minute, length_light_minute);
+BOOST_UNITS_STATIC_CONSTANT(light_minutes, length_light_minute);
+
+typedef bua::light_second_base_unit::unit_type length_light_second;
+BOOST_UNITS_STATIC_CONSTANT(light_second, length_light_second);
+BOOST_UNITS_STATIC_CONSTANT(light_seconds, length_light_second);
+
+typedef bua::light_year_base_unit::unit_type length_light_year;
+BOOST_UNITS_STATIC_CONSTANT(light_year, length_light_year);
+BOOST_UNITS_STATIC_CONSTANT(light_years, length_light_year);
+
+typedef bua::parsec_base_unit::unit_type length_parsec;
+BOOST_UNITS_STATIC_CONSTANT(parsec, length_parsec);
+BOOST_UNITS_STATIC_CONSTANT(parsecs, length_parsec);
+
+typedef bu::si::length length_meter;
+typedef bu::si::length length_metre;
+BOOST_UNITS_STATIC_CONSTANT(meter, length_meter);
+BOOST_UNITS_STATIC_CONSTANT(meters, length_meter);
+BOOST_UNITS_STATIC_CONSTANT(metre, length_meter);
+BOOST_UNITS_STATIC_CONSTANT(metres, length_meter);
+
+typedef bu::cgs::length length_centimeter;
+typedef bu::cgs::length length_centimetre;
+BOOST_UNITS_STATIC_CONSTANT(centimeter, length_centimeter);
+BOOST_UNITS_STATIC_CONSTANT(centimeters, length_centimeter);
+BOOST_UNITS_STATIC_CONSTANT(centimetre, length_centimeter);
+BOOST_UNITS_STATIC_CONSTANT(centimetres, length_centimeter);
+
+}}} //namespace boost::astronomy::units
+
+
+#endif // !BOOST_ASTRONOMY_UNITS_UNITS_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(header)
 
 add_subdirectory(coordinate)
+
+add_subdirectory(units)

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,3 +10,4 @@ project
 
 build-project header ;
 build-project coordinate ;
+build-project units ;

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -18,6 +18,11 @@ file(GLOB_RECURSE  _hpp_io RELATIVE
   "${CMAKE_SOURCE_DIR}/include/boost/astronomy/io/*.hpp")
 list(APPEND _headers ${_hpp_io})
 
+file(GLOB_RECURSE  _hpp_units RELATIVE
+  "${CMAKE_SOURCE_DIR}/include/boost/astronomy"
+  "${CMAKE_SOURCE_DIR}/include/boost/astronomy/units/*.hpp")
+list(APPEND _headers ${_hpp_units})
+
 #-----------------------------------------------------------------------------
 # Target: test_headers_self_contained
 # Bundles all targets of self-contained header tests,

--- a/test/header/Jamfile
+++ b/test/header/Jamfile
@@ -33,4 +33,4 @@ rule generate_self_contained_headers ( headers_subpath * : exclude_subpaths * )
     return $(targets) ;
 }
 
-alias headers : [ generate_self_contained_headers coordinate exception io : detail ] ;
+alias headers : [ generate_self_contained_headers coordinate exception io units : detail ] ;

--- a/test/units/CMakeLists.txt
+++ b/test/units/CMakeLists.txt
@@ -1,0 +1,16 @@
+foreach(_name
+        length)
+    set(_target test_units_${_name})
+
+    add_executable(${_target} "")
+    target_sources(${_target} PRIVATE ${_name}.cpp)
+    target_link_libraries(${_target}
+            PRIVATE
+            astronomy_compile_options
+            astronomy_include_directories
+            astronomy_dependencies)
+    add_test(NAME test.astro.${_name} COMMAND ${_target})
+
+    unset(_name)
+    unset(_target)
+endforeach()

--- a/test/units/Jamfile
+++ b/test/units/Jamfile
@@ -1,0 +1,3 @@
+import testing ;
+
+run length.cpp ;

--- a/test/units/length.cpp
+++ b/test/units/length.cpp
@@ -1,0 +1,164 @@
+#define BOOST_TEST_MODULE unit_length_test
+
+#include <boost/test/unit_test.hpp>
+#include <boost/units/quantity.hpp>
+#include <boost/units/systems/si/length.hpp>
+#include <boost/units/systems/cgs/length.hpp>
+#include <boost/astronomy/units/length.hpp>
+
+namespace bu = boost::units;
+namespace bau = boost::astronomy::units;
+
+
+BOOST_AUTO_TEST_SUITE(length_unit)
+
+BOOST_AUTO_TEST_CASE(units_astronomical_unit)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::astronomical_unit_base_unit::unit_type>,
+        bu::quantity<bau::length_astronomical_unit>>::value
+        ));
+
+    bu::quantity<
+        bu::astronomical::astronomical_unit_base_unit::unit_type,
+        int
+    > q1 = 10 * bau::astronomical_unit;
+    bu::quantity<bau::length_astronomical_unit, int> q2 = 10 * bau::astronomical_units;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_light_day)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::light_day_base_unit::unit_type>,
+        bu::quantity<bau::length_light_day>>::value
+        ));
+
+    bu::quantity<bu::astronomical::light_day_base_unit::unit_type, int> q1 = 10 * bau::light_day;
+    bu::quantity<bau::length_light_day, int> q2 = 10 * bau::light_days;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_light_hour)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::light_hour_base_unit::unit_type>,
+        bu::quantity<bau::length_light_hour>>::value
+        ));
+
+    bu::quantity<bu::astronomical::light_hour_base_unit::unit_type, int> q1 = 10 * bau::light_hour;
+    bu::quantity<bau::length_light_hour, int> q2 = 10 * bau::light_hour;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_light_minute)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::light_minute_base_unit::unit_type>,
+        bu::quantity<bau::length_light_minute>>::value
+        ));
+
+    bu::quantity<bu::astronomical::light_minute_base_unit::unit_type> q1 = 10 * bau::light_minute;
+    bu::quantity<bau::length_light_minute, int> q2 = 10 * bau::light_minutes;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_light_second)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::light_second_base_unit::unit_type>,
+        bu::quantity<bau::length_light_second>>::value
+        ));
+
+    bu::quantity<bu::astronomical::light_second_base_unit::unit_type> q1 = 10 * bau::light_second;
+    bu::quantity<bau::length_light_second, int> q2 = 10 * bau::light_seconds;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_light_year)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::light_year_base_unit::unit_type>,
+        bu::quantity<bau::length_light_year>>::value
+        ));
+
+    bu::quantity<bu::astronomical::light_year_base_unit::unit_type, int> q1 = 10 * bau::light_year;
+    bu::quantity<bau::length_light_year, int> q2 = 10 * bau::light_years;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_parsec)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::astronomical::parsec_base_unit::unit_type>,
+        bu::quantity<bau::length_parsec>>::value
+        ));
+
+    bu::quantity<bu::astronomical::parsec_base_unit::unit_type, int> q1 = 10 * bau::parsec;
+    bu::quantity<bau::length_parsec, int> q2 = 10 * bau::parsecs;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_meter)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::si::length>,
+        bu::quantity<bau::length_meter>>::value
+        ));
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::si::length>,
+        bu::quantity<bau::length_metre>>::value
+        ));
+
+    bu::quantity<bu::si::length, int> q1 = 10 * bau::meter;
+    bu::quantity<bau::length_meter, int> q2 = 10 * bau::meters;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+
+    q1 = 10 * bau::metre;
+    q2 = 10 * bau::metres;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_CASE(units_centimeter)
+{
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::cgs::length>,
+        bu::quantity<bau::length_centimeter>>::value
+        ));
+    BOOST_TEST((std::is_same<
+        bu::quantity<bu::cgs::length>,
+        bu::quantity<bau::length_centimetre>>::value
+        ));
+
+    bu::quantity<bu::cgs::length, int> q1 = 10 * bau::centimeter;
+    bu::quantity<bau::length_centimeter, int> q2 = 10 * bau::centimeters;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+
+    q1 = 10 * bau::centimetre;
+    q2 = 10 * bau::centimetres;
+
+    BOOST_TEST((q1.value() == 10));
+    BOOST_TEST((q1 == q2));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Description

New alias and simple `units_static_constant` are provided to hide the complexity of `boost::units` from the user.

### References

- Closes #9 

### Tasklist

- [x] Add test case(s)
- [ ] Ensure all CI builds pass
- [x] Review and approve
