### PR TITLE
C++ standard changed to C++14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,16 @@
 *.exe
 *.out
 *.app
+
+# Builds
 /.vs
+/.vscode
+/build
+/.idea
+/cmake-build-debug
+/x64/Debug
+
+# Project files
 /include/boost/astronomy/coordinate/Source.cpp
 /testing
 /Debug
@@ -39,9 +48,6 @@
 /astronomy.vcxproj.filters
 /astronomy.vcxproj
 /astronomy.sln
-/ClassDiagram.cd
-/doc/tutorials/.vscode/settings.json
-/.idea
-/cmake-build-debug
 *.user
-/x64/Debug
+/ClassDiagram.cd
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.10)
 option(ASTRONOMY_BUILD_TEST "Build tests" ON)
 option(ASTRONOMY_USE_CLANG_TIDY "Set CMAKE_CXX_CLANG_TIDY property on targets to enable clang-tidy linting" OFF)
 option(ASTRONOMY_DOWNLOAD_FINDBOOST "Download FindBoost.cmake from latest CMake release" OFF)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard version to use (default is 14)")
 
 #-----------------------------------------------------------------------------
 # Project


### PR DESCRIPTION
C++ standard changed to C++14 from C++11
(Using `auto` for return type in functions became absolutely necessary because of the long return types generated with multiple or by multiplying `boost::units::unit` or `boost::units::quantity`)

build folders added to `.gitignore`