### PR TITLE
Integrated spherical_representation with units

### DIFF
--- a/include/boost/astronomy/coordinate/spherical_representation.hpp
+++ b/include/boost/astronomy/coordinate/spherical_representation.hpp
@@ -3,149 +3,446 @@
 
 
 #include <tuple>
+#include <cstddef>
+
+#include <boost/static_assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/algorithms/transform.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
-#include <boost/static_assert.hpp>
+#include <boost/units/physical_dimensions/plane_angle.hpp>
+#include <boost/units/systems/si/plane_angle.hpp>
+#include <boost/units/systems/si/dimensionless.hpp>
 
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_representation.hpp>
 #include <boost/astronomy/coordinate/cartesian_representation.hpp>
-#include <boost/astronomy/coordinate/spherical_differential.hpp>
-#include <boost/astronomy/coordinate/spherical_coslat_differential.hpp>
 
 
-namespace boost
+namespace boost { namespace astronomy { namespace coordinate {
+
+namespace bu = boost::units;
+namespace bg = boost::geometry;
+
+
+//!Represents the coordinate in spherical representation
+//!Uses three components to represent a point/vector (latitude, longitude, distance)
+/*!
+\brief Spherical (polar) coordinate system, in degree or in radian
+\details Defines the spherical coordinate system where points are
+    defined in two angles
+    and an optional radius usually known as r, theta, phi
+\par Coordinates:
+- coordinate 0:
+    0 <= phi < 2pi is the angle between the positive x-axis and the
+        line from the origin to the P projected onto the xy-plane.
+- coordinate 1:
+    0 <= theta <= pi is the angle between the positive z-axis and the
+        line formed between the origin and P.
+- coordinate 2 (if specified):
+    r >= 0 is the distance from the origin to a given point P.
+
+\see http://en.wikipedia.org/wiki/Spherical_coordinates
+\ingroup cs
+*/
+template
+<
+    typename CoordinateType = double,
+    typename LatQuantity = bu::quantity<bu::si::plane_angle, CoordinateType>,
+    typename LonQuantity = bu::quantity<bu::si::plane_angle, CoordinateType>,
+    typename DistQuantity = bu::quantity<bu::si::dimensionless, CoordinateType>
+>
+struct spherical_representation : public base_representation
+    <3, bg::cs::spherical<radian>, CoordinateType>
 {
-    namespace astronomy
+    ///@cond INTERNAL
+    BOOST_STATIC_ASSERT_MSG(
+        ((std::is_same<typename bu::get_dimension<LatQuantity>::type,
+            bu::plane_angle_dimension>::value) &&
+            (std::is_same<typename bu::get_dimension<LonQuantity>::type,
+            bu::plane_angle_dimension>::value)),
+        "Latitude and Longitude must be of plane angle type");
+    BOOST_STATIC_ASSERT_MSG((std::is_floating_point<CoordinateType>::value),
+        "CoordinateType must be a floating-point type");
+    ///@endcond
+
+public:
+    typedef LatQuantity quantity1;
+    typedef LonQuantity quantity2;
+    typedef DistQuantity quantity3;
+
+    //default constructor no initialization
+    spherical_representation() {}
+
+    //!constructs object from provided value of coordinates (latitude, longitude, distance)
+    spherical_representation
+    (
+        LatQuantity const& lat,
+        LonQuantity const& lon,
+        DistQuantity const& distance
+    )
     {
-        namespace coordinate
-        {
-            //!Represents the coordinate in spherical representation
-            //!Uses three components to represent a point/vector (latitude, longitude, distance)
-            template <typename DegreeOrRadian>
-            struct spherical_representation : public boost::astronomy::coordinate::base_representation
-                <3, boost::geometry::cs::spherical<DegreeOrRadian>>
-            {
-            public:
-                //default constructor no initialization
-                spherical_representation() {}
+        this->set_lat_lon_dist(lat, lon, distance);
+    }
 
-                //!constructs object from provided value of coordinates (latitude, longitude, distance)
-                spherical_representation(double lat, double lon, double distance = 1.0)
-                {
-                    boost::geometry::set<0>(this->point, lat);
-                    boost::geometry::set<1>(this->point, lon);
-                    boost::geometry::set<2>(this->point, distance);
-                }
+    //!constructs object from boost::geometry::model::point object
+    template
+    <
+        std::size_t OtherDimensionCount,
+        typename OtherCoordinateSystem,
+        typename OtherCoordinateType
+    >
+    spherical_representation
+    (
+        bg::model::point
+        <
+            OtherCoordinateType,
+            OtherDimensionCount,
+            OtherCoordinateSystem
+        > const& pointObject
+    )
+    {
+        bg::model::point<OtherCoordinateType, 3, bg::cs::cartesian> temp;
+        bg::transform(pointObject, temp);
+        bg::transform(temp, this->point);
+    }
 
-                //!constructs object from boost::geometry::model::point object
-                template<std::size_t DimensionCount, typename System>
-                spherical_representation(boost::geometry::model::point<double, DimensionCount, System> const& pointObject)
-                {
-                    boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian> temp;
-                    boost::geometry::transform(pointObject, temp);
-                    boost::geometry::transform(temp, this->point);
-                }
+    //copy constructor
+    spherical_representation
+    (
+        spherical_representation
+        <
+            CoordinateType,
+            LatQuantity,
+            LonQuantity,
+            DistQuantity
+        > const& other)
+    {
+        this->point = other.get_point();
+    }
 
-                //copy constructor
-                spherical_representation(spherical_representation<DegreeOrRadian> const& other)
-                {
-                    this->point = other.get_point();
-                }
+    //!constructs object from any type of representation
+    template <typename Representation>
+    spherical_representation(Representation const& other)
+    {
+        BOOST_STATIC_ASSERT_MSG((boost::astronomy::detail::is_base_template_of
+            <boost::astronomy::coordinate::base_representation, Representation>::value),
+            "No constructor found with given argument type");
 
-                //!constructs object from any type of representation
-                template <typename Representation>
-                spherical_representation(Representation const& other)
-                {
-                    BOOST_STATIC_ASSERT_MSG((boost::astronomy::detail::is_base_template_of
-                        <boost::astronomy::coordinate::base_representation, Representation>::value),
-                        "No constructor found with given argument type");
+        auto temp = make_spherical_representation(other);
+        bg::transform(temp.get_point(), this->point);
+    }
 
-                    boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian> temp;
-                    boost::geometry::transform(other.get_point(), temp);
-                    boost::geometry::transform(temp, this->point);
-                }
+    //! returns the (lat, lon, distance) in the form of tuple
+    std::tuple<LatQuantity, LonQuantity, DistQuantity> get_lat_lon_dist() const
+    {
+        return std::make_tuple(this->get_lat(), this->get_lon(), this->get_dist());
+    }
 
-                //! returns the (lat, lon, distance) in the form of tuple
-                std::tuple<double, double, double> get_lat_lon_dist() const
-                {
-                    return std::make_tuple(boost::geometry::get<0>(this->point),
-                        boost::geometry::get<1>(this->point), boost::geometry::get<2>(this->point));
-                }
+    //!returns the lat component of point
+    LatQuantity get_lat() const
+    {
+        return static_cast<LatQuantity>
+            (
+                bu::quantity<bu::si::plane_angle, CoordinateType>::from_value
+                    (bg::get<0>(this->point))
+            );
+    }
 
-                //!returns the lat component of point
-                double get_lat() const
-                {
-                    return boost::geometry::get<0>(this->point);
-                }
+    //!returns the lon component of point
+    LonQuantity get_lon() const
+    {
+        return static_cast<LonQuantity>
+            (
+                bu::quantity<bu::si::plane_angle, CoordinateType>::from_value
+                    (bg::get<1>(this->point))
+            );
+    }
 
-                //!returns the lon component of point
-                double get_lon() const
-                {
-                    return boost::geometry::get<1>(this->point);
-                }
+    //!returns the distance component of point
+    DistQuantity get_dist() const
+    {
+        return DistQuantity::from_value(bg::get<2>(this->point));
+    }
 
-                //!returns the distance component of point
-                double get_dist() const
-                {
-                    return boost::geometry::get<2>(this->point);
-                }
+    //!set value of (lat, lon, distance) in current object
+    void set_lat_lon_dist
+    (
+        LatQuantity const& lat,
+        LonQuantity const& lon,
+        DistQuantity const& distance
+    )
+    {
+        this->set_lat(lat);
+        this->set_lon(lon);
+        this->set_dist(distance);
+    }
 
-                //!set value of (lat, lon, distance) in current object
-                void set_lat_lon_dist(double lat, double lon, double distance)
-                {
-                    boost::geometry::set<0>(this->point, lat);
-                    boost::geometry::set<1>(this->point, lon);
-                    boost::geometry::set<2>(this->point, distance);
-                }
+    //!set value of lat component of point
+    void set_lat(LatQuantity const& lat)
+    {
+        bg::set<0>
+            (
+            this->point,
+            static_cast<bu::quantity<bu::si::plane_angle, CoordinateType>>(lat).value()
+            );
+    }
 
-                //!set value of lat component of point
-                void set_lat(double lat)
-                {
-                    boost::geometry::set<0>(this->point, lat);
-                }
+    //!set value of lon component of point
+    void set_lon(LonQuantity const& lon)
+    {
+        bg::set<1>
+            (
+            this->point,
+            static_cast<bu::quantity<bu::si::plane_angle, CoordinateType>>(lon).value()
+            );
+    }
 
-                //!set value of lon component of point
-                void set_lon(double lon)
-                {
-                    boost::geometry::set<1>(this->point, lon);
-                }
+    //!set value of distance component of point
+    void set_dist(DistQuantity const& distance)
+    {
+        bg::set<2>(this->point, distance.value());
+    }
 
-                //!set value of distance component of point
-                void set_dist(double distance)
-                {
-                    boost::geometry::set<2>(this->point, distance);
-                }
+    template<typename Addend>
+    spherical_representation
+    <
+        CoordinateType,
+        LatQuantity,
+        LonQuantity,
+        DistQuantity
+    > 
+    operator +(Addend const& addend) const
+    {
 
-                boost::astronomy::coordinate::spherical_representation<DegreeOrRadian>
-                    operator +(boost::astronomy::coordinate::spherical_differential<DegreeOrRadian> const& diff) const
-                {
-                    boost::astronomy::coordinate::spherical_representation<DegreeOrRadian> temp(this->point);
 
-                    temp.set_lat(temp.get_lat() + diff.get_dlat());
-                    temp.set_lon(temp.get_lon() + diff.get_dlon());
-                    temp.set_dist(temp.get_dist() + diff.get_ddist());
+        auto cartesian1 = make_cartesian_representation
+            <CoordinateType, DistQuantity, DistQuantity, DistQuantity>(this->point);
+        auto cartesian2 = make_cartesian_representation(addend);
 
-                    return temp;
-                }
+        auto temp = cartesian1 + cartesian2;
 
-                boost::astronomy::coordinate::spherical_representation<DegreeOrRadian>
-                    operator +(boost::astronomy::coordinate::spherical_coslat_differential<DegreeOrRadian> const& diff) const
-                {
-                    boost::astronomy::coordinate::spherical_representation<DegreeOrRadian> temp(this->diff);
+        spherical_representation
+        <
+            CoordinateType,
+            LatQuantity,
+            LonQuantity,
+            DistQuantity
+        > result = make_spherical_differential(temp);
 
-                    temp.set_dlat(temp.get_lat() + diff.get_dlat());
-                    temp.set_dlon_coslat(temp.get_lon() + diff.get_dlon_coslat());
-                    temp.set_ddist(temp.get_dist() + diff.get_ddist());
+        return result;
+    }
 
-                    return temp;
-                }
-            };
-        }//namespace coordinate
-    } //namespace astronomy
-} //namespace boost
+}; //spherical_representation
+
+
+//!Constructs object from provided quantities
+//!Each quantity can have different units but with same datatypes
+template
+<
+    typename CoordinateType,
+    template <typename Unit1, typename CoordinateType_> class LatQuantity,
+    template <typename Unit2, typename CoordinateType_> class LonQuantity,
+    template <typename Unit3, typename CoordinateType_> class DistQuantity,
+    typename Unit1,
+    typename Unit2,
+    typename Unit3
+>
+spherical_representation
+<
+    CoordinateType,
+    LatQuantity<Unit1, CoordinateType>,
+    LonQuantity<Unit2, CoordinateType>,
+    DistQuantity<Unit3, CoordinateType>
+> make_spherical_representation
+(
+    LatQuantity<Unit1, CoordinateType> const& lat,
+    LonQuantity<Unit2, CoordinateType> const& lon,
+    DistQuantity<Unit3, CoordinateType> const& dist
+)
+{
+    return spherical_representation
+        <
+            CoordinateType,
+            LatQuantity<Unit1, CoordinateType>,
+            LonQuantity<Unit2, CoordinateType>,
+            DistQuantity<Unit3, CoordinateType>
+        >(lat, lon, dist);
+}
+
+//!Convert current quantities of spherical_representation to new quantities. 
+template
+<
+    typename ReturnCoordinateType,
+    typename ReturnLatQuantity,
+    typename ReturnLonQuantity,
+    typename ReturnDistQuantity,
+    typename CoordinateType,
+    typename LatQuantity,
+    typename LonQuantity,
+    typename DistQuantity
+>
+spherical_representation
+<
+    ReturnCoordinateType,
+    ReturnLatQuantity,
+    ReturnLonQuantity,
+    ReturnDistQuantity
+>
+make_spherical_representation
+(
+    spherical_representation
+    <
+        CoordinateType,
+        LatQuantity,
+        LonQuantity,
+        DistQuantity
+    > const& other
+)
+{
+    return make_cartesian_representation(
+        static_cast<ReturnLatQuantity>(other.get_x()),
+        static_cast<ReturnLonQuantity>(other.get_y()),
+        static_cast<ReturnDistQuantity>(other.get_z())
+    );
+}
+
+//!Create copy of spherical_representation
+template
+<
+    typename CoordinateType,
+    typename LatQuantity,
+    typename LonQuantity,
+    typename DistQuantity
+>
+spherical_representation<CoordinateType, LatQuantity, LonQuantity, DistQuantity>
+make_spherical_representation
+(
+    spherical_representation
+    <
+        CoordinateType,
+        LatQuantity,
+        LonQuantity,
+        DistQuantity
+    > const& other
+)
+{
+    return spherical_representation
+        <
+        CoordinateType,
+        LatQuantity,
+        LonQuantity,
+        DistQuantity
+        >(other);
+}
+
+//!Create spherical_representation from boost::geometry::point
+//!Quantity types are to be specifed explicitly or angle is considered to be in radians
+//!distance is taken dimensionless by default if not specified 
+template
+<
+    typename CoordinateType=double,
+    typename LatQuantity = bu::quantity<bu::si::plane_angle, CoordinateType>,
+    typename LonQuantity = bu::quantity<bu::si::plane_angle, CoordinateType>,
+    typename DistQuantity = bu::quantity<bu::si::dimensionless, CoordinateType>,
+    std::size_t OtherDimensionCount,
+    typename OtherCoordinateSystem,
+    typename OtherCoordinateType
+>
+spherical_representation<CoordinateType, LatQuantity, LonQuantity, DistQuantity>
+make_spherical_representation
+(
+    bg::model::point
+    <
+    OtherCoordinateType,
+    OtherDimensionCount,
+    OtherCoordinateSystem
+    > const& pointObject)
+{
+    return spherical_representation
+        <
+        CoordinateType,
+        LatQuantity,
+        LonQuantity,
+        DistQuantity
+        >(pointObject);
+}
+
+//!Create cartesian_representation from other type of representations
+template
+<
+    typename CoordinateType,
+    typename XQuantity,
+    typename YQuantity,
+    typename ZQuantity
+>
+spherical_representation
+<
+    CoordinateType,
+    bu::quantity<bu::si::plane_angle, CoordinateType>,
+    bu::quantity<bu::si::plane_angle, CoordinateType>,
+    XQuantity
+> make_spherical_representation
+(cartesian_representation<CoordinateType, XQuantity, YQuantity, ZQuantity> const& other)
+{
+    typedef cartesian_representation
+        <
+        CoordinateType,
+        XQuantity,
+        YQuantity,
+        ZQuantity
+        > cartesian_type;
+
+    bg::model::point<typename cartesian_type::type, 3, bg::cs::cartesian> tempPoint;
+    bg::model::point<typename cartesian_type::type, 3, bg::cs::spherical<radian>> result;
+
+    bg::set<0>(tempPoint, other.get_x().value());
+    bg::set<1>
+    (
+        tempPoint,
+        static_cast<typename cartesian_type::quantity1>
+        (other.get_y()).value()
+    );
+    bg::set<2>
+    (
+        tempPoint,
+        static_cast<typename cartesian_type::quantity1>
+        (other.get_z()).value()
+    );
+
+    bg::transform(tempPoint, result);
+
+    return spherical_representation
+        <
+            typename cartesian_type::type,
+            bu::quantity<bu::si::plane_angle, typename cartesian_type::type>,
+            bu::quantity<bu::si::plane_angle, typename cartesian_type::type>,
+            typename cartesian_type::quantity1
+        >(result);
+}
+
+//!Create spherical_equatorial_representation from other type of representations
+//A general implementation is used to avoid including spherical_equatorial_representation.hpp
+//error: using spherical_equatorial_representation before it's declaration
+template<typename OtherRepresentation>
+spherical_representation
+<
+    typename OtherRepresentation::type,
+    typename OtherRepresentation::quantity1,
+    typename OtherRepresentation::quantity2,
+    typename OtherRepresentation::quantity3
+>
+make_spherical_representation(OtherRepresentation const& other)
+{
+    return spherical_representation
+        <
+        typename OtherRepresentation::type,
+        typename OtherRepresentation::quantity1,
+        typename OtherRepresentation::quantity2,
+        typename OtherRepresentation::quantity3
+        >(other.get_point());
+}
+
+}}} //namespace boost::astronomy::coordinate
+
 #endif // !BOOST_ASTRONOMY_COORDINATE_SPHERICAL_REPRESENTATION_HPP
-
-

--- a/test/representation.cpp
+++ b/test/representation.cpp
@@ -5,10 +5,13 @@
 #include <boost/units/quantity.hpp>
 #include <boost/units/systems/si/prefixes.hpp>
 #include <boost/units/systems/si/length.hpp>
+#include <boost/units/systems/si/plane_angle.hpp>
+#include <boost/units/systems/angle/degrees.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/point.hpp>
 
 #include <boost/astronomy/coordinate/cartesian_representation.hpp>
+#include <boost/astronomy/coordinate/spherical_representation.hpp>
 #include <boost/astronomy/coordinate/arithmetic.hpp>
 
 
@@ -17,7 +20,7 @@ using namespace boost::astronomy::coordinate;
 using namespace boost::units::si;
 using namespace boost::geometry;
 using namespace boost::units;
-
+namespace bud = boost::units::degree;
 
 BOOST_AUTO_TEST_SUITE(representation_constructor)
 
@@ -37,56 +40,59 @@ BOOST_AUTO_TEST_CASE(cartesian)
     BOOST_CHECK_CLOSE(point1.get_z().value(), point2.get_z().value(), 0.001);
 
     //constructing from boost::geometry::model::point
-    model::point<double, 2, cs::spherical<degree>> model_point(30, 60);
+    model::point<double, 2, cs::spherical<boost::geometry::degree>> model_point(30, 60);
     auto point3 = make_cartesian_representation
-        <double, quantity<length>, quantity<length>, quantity<length>>(model_point);
+    <double,quantity<si::length>,quantity<si::length>,quantity<si::length>>(model_point);
     BOOST_CHECK_CLOSE(point3.get_x().value(), 0.75, 0.001);
     BOOST_CHECK_CLOSE(point3.get_y().value(), 0.4330127019, 0.001);
     BOOST_CHECK_CLOSE(point3.get_z().value(), 0.5, 0.001);
 
     //Conversion from one unit type to other
     auto point4 = make_cartesian_representation
-        <double, quantity<length>, quantity<length>, quantity<length>>(point1);
+    <double, quantity<si::length>, quantity<si::length>, quantity<si::length>>(point1);
     BOOST_CHECK_CLOSE(point4.get_x().value(), 1.5, 0.001);
     BOOST_CHECK_CLOSE(point4.get_y().value(), 9000.0, 0.001);
     BOOST_CHECK_CLOSE(point4.get_z().value(), 0.03, 0.001);
 
-    ////constructing from another representation
-    //spherical_representation<radian> spherical_point(0.523599, 1.047198, 1);
-    //cartesian_representation point4(spherical_point);
-    //BOOST_CHECK_CLOSE(point4.get_x(), 0.75, 0.001);
-    //BOOST_CHECK_CLOSE(point4.get_y(), 0.4330127019, 0.001);
-    //BOOST_CHECK_CLOSE(point4.get_z(), 0.5, 0.001);
+    //constructing from another representation
+    auto spherical_point = make_spherical_representation
+    (0.523599 * si::radian, 60.0 * bud::degrees, 1.0 * meters);
+    auto point5 = make_cartesian_representation(spherical_point);
+    BOOST_CHECK_CLOSE(point5.get_x().value(), 0.75, 0.001);
+    BOOST_CHECK_CLOSE(point5.get_y().value(), 0.4330127019, 0.001);
+    BOOST_CHECK_CLOSE(point5.get_z().value(), 0.5, 0.001);
 }
 
-//BOOST_AUTO_TEST_CASE(spherical)
-//{
-//    //checking construction from value
-//    spherical_representation<degree> point1(45.0, 18, 3.5);
-//    BOOST_CHECK_CLOSE(point1.get_lat(), 45.0, 0.001);
-//    BOOST_CHECK_CLOSE(point1.get_lon(), 18.0, 0.001);
-//    BOOST_CHECK_CLOSE(point1.get_dist(), 3.5, 0.001);
-//
-//    //copy constructor
-//    spherical_representation<degree> point2(point1);
-//    BOOST_CHECK_CLOSE(point1.get_lat(), point2.get_lat(), 0.001);
-//    BOOST_CHECK_CLOSE(point1.get_lon(), point2.get_lon(), 0.001);
-//    BOOST_CHECK_CLOSE(point1.get_dist(), point2.get_dist(), 0.001);
-//
-//    //constructing from boost::geometry::model::point
-//    boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian> model_point(50, 20, 30);
-//    spherical_representation<radian> point3(model_point);
-//    BOOST_CHECK_CLOSE(point3.get_lat(), 0.38050637711237, 0.001);
-//    BOOST_CHECK_CLOSE(point3.get_lon(), 1.0625290806236, 0.001);
-//    BOOST_CHECK_CLOSE(point3.get_dist(), 61.64414002969, 0.001);
-//
-//    //constructing from another representation
-//    cartesian_representation cartesian_point(60, 45, 85);
-//    spherical_representation<degree> point4(cartesian_point);
-//    BOOST_CHECK_CLOSE(point4.get_lat(), 36.869897645844, 0.001);
-//    BOOST_CHECK_CLOSE(point4.get_lon(), 41.423665625003, 0.001);
-//    BOOST_CHECK_CLOSE(point4.get_dist(), 113.35784048755, 0.001);
-//}
+BOOST_AUTO_TEST_CASE(spherical)
+{
+    //checking construction from value
+    auto point1 = make_spherical_representation
+        (45.0 * bud::degrees, 18.0 * si::radians, 3.0 * meters);
+    BOOST_CHECK_CLOSE(point1.get_lat().value(), 45.0, 0.001);
+    BOOST_CHECK_CLOSE(point1.get_lon().value(), 18.0, 0.001);
+    BOOST_CHECK_CLOSE(point1.get_dist().value(), 3.0, 0.001);
+
+    //copy constructor
+    auto point2 = make_spherical_representation(point1);
+    BOOST_CHECK_CLOSE(point2.get_lat().value(), point1.get_lat().value(), 45.0, 0.001);
+    BOOST_CHECK_CLOSE(point2.get_lon().value(), point1.get_lon().value(), 18.0, 0.001);
+    BOOST_CHECK_CLOSE(point2.get_dist().value(), point1.get_dist().value(), 3.0, 0.001);
+
+    //constructing from boost::geometry::model::point
+    model::point<double, 3, boost::geometry::cs::cartesian> model_point(50, 20, 30);
+    auto point3 = make_spherical_representation(model_point);
+    BOOST_CHECK_CLOSE(point3.get_lat().value(), 0.38050637711237, 0.001);
+    BOOST_CHECK_CLOSE(point3.get_lon().value(), 1.0625290806236, 0.001);
+    BOOST_CHECK_CLOSE(point3.get_dist().value(), 61.64414002969, 0.001);
+
+    //constructing from another representation
+    auto cartesian_point = make_cartesian_representation(60.0*meter, 45.0*meter, 85.0*meter);
+    auto point4 = make_spherical_representation(cartesian_point);
+    BOOST_CHECK_CLOSE(point4.get_lat().value(), 0.64350110879328, 0.001);
+    BOOST_CHECK_CLOSE(point4.get_lon().value(), 0.72297935340149, 0.001);
+    BOOST_CHECK_CLOSE(point4.get_dist().value(), 113.35784048755, 0.001);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(representation_functions)


### PR DESCRIPTION
### Description

made `spherical_representation` able to accept `boost::units::quantity` and store the data appropriately.

### References

- Closes #15 

### Tasklist

- [x] Add test case(s)
- [ ] Review and approve
