### PR TITLE
Irregular behaviour in fits file reading resolved

### DIFF
--- a/include/boost/astronomy/io/primary_hdu.hpp
+++ b/include/boost/astronomy/io/primary_hdu.hpp
@@ -27,8 +27,6 @@ public:
     //!This constructore should be used when file is never read and boost::astronomy::io::hdu object is not created of the file
     primary_hdu(std::fstream &file) : hdu(file)
     {
-        //primary header always starts at the begining of the file
-        file.seekg(0);
         simple = this->value_of<bool>("SIMPLE");
         extend = this->value_of<bool>("EXTEND");
 
@@ -55,8 +53,6 @@ public:
     //!This constructore should be used when boost::astronomy::io::hdu object already exist for the file 
     primary_hdu(std::fstream &file, hdu const& other) : hdu(other)
     {
-        //primary header always starts at the begining of the file
-        file.seekg(0);
         simple = this->value_of<bool>("SIMPLE");
         extend = this->value_of<bool>("EXTEND");
 


### PR DESCRIPTION
### Description
While constructing `primary_hdu`, it used to read file from the beginning every time which caused the problem in `fits` class. Now `primary_hdu` can be constructed from any point of the file.

### Tasklist

- [ ] Ensure all CI builds pass
- [ ] Review and approve