### PR TITLE
`table_extension`, `column`, `column_data` classes added

### DIFF
--- a/include/boost/astronomy/exception/fits_exception.hpp
+++ b/include/boost/astronomy/exception/fits_exception.hpp
@@ -16,6 +16,15 @@ namespace boost
             }
         };
 
+        class wrong_extension_type :public fits_exception
+        {
+        public:
+            const char* what() const throw()
+            {
+                return "wrong extension type";
+            }
+        };
+
         class invalid_card_length_exception : public fits_exception
         {
         public:
@@ -58,6 +67,15 @@ namespace boost
             const char* what() const throw()
             {
                 return "Key is not defined";
+            }
+        };
+
+        class invalid_table_colum_format : public fits_exception
+        {
+        public:
+            const char* what() const throw()
+            {
+                return "invalid_table_colum_format";
             }
         };
 

--- a/include/boost/astronomy/io/column.hpp
+++ b/include/boost/astronomy/io/column.hpp
@@ -1,0 +1,142 @@
+#ifndef BOOST_ASTRONOMY_IO_COLUMN_HPP
+#define BOOST_ASTRONOMY_IO_COLUMN_HPP
+
+#include <string>
+#include <cstddef>
+
+#include <boost/static_assert.hpp>
+
+#include <boost/astronomy/io/hdu.hpp>
+
+namespace boost { namespace astronomy { namespace io {
+
+struct hdu;
+
+struct column
+{
+private:
+    std::size_t index_;     //index
+    std::string name;       //TTYPE
+    std::size_t start;      //TBCOL
+    std::string format;     //TFORM
+    std::string unit;       //TUNIT
+    double scale;           //TSCAL
+    double zero;            //TZERO
+    std::string display;    //TDISP
+    std::string dimension;   //TDIM
+    std::string comment_;
+
+public:
+
+    column(){}
+
+    column(std::size_t tbcol, std::string tform): start(tbcol), format(tform) {}
+
+    column(std::string tform) : format(tform) {}
+
+    void index(std::size_t i)
+    {
+        index_ = i;
+    }
+
+    std::size_t index() const
+    {
+        return index_;
+    }
+
+    std::size_t TBCOL() const
+    {
+        return start;
+    }
+
+    void TBCOL(std::size_t tbcol)
+    {
+        start = tbcol;
+    }
+
+    std::string TTYPE() const
+    {
+        return name;
+    }
+
+    void TTYPE(std::string ttype)
+    {
+        name = ttype;
+    }
+
+    std::string comment() const
+    {
+        return comment_;
+    }
+
+    void comment(std::string com)
+    {
+        comment_ = com;
+    }
+
+    std::string TFORM() const
+    {
+        return format;
+    }
+
+    void TFORM(std::string tform)
+    {
+        format = tform;
+    }
+
+    std::string TUNIT() const
+    {
+        return unit;
+    }
+
+    void TUNIT(std::string tunit)
+    {
+        unit = tunit;
+    }
+
+    double TSCAL() const
+    {
+        return scale;
+    }
+
+    void TSCAL(double tscal)
+    {
+        scale = tscal;
+    }
+
+    double TZERO() const
+    {
+        return zero;
+    }
+
+    void TZERO(double tzero)
+    {
+        zero = tzero;
+    }
+
+    std::string TDISP() const
+    {
+        return display;
+    }
+
+    void TDISP(std::string tdisp)
+    {
+        display = tdisp;
+    }
+
+    std::string TDIM() const
+    {
+        return dimension;
+    }
+
+    void TDIM(std::string tdim)
+    {
+        dimension = tdim;
+    }
+
+    friend struct hdu;
+};
+
+}}}
+
+#endif // !BOOST_ASTRONOMY_IO_COLUMN_HPP

--- a/include/boost/astronomy/io/column_data.hpp
+++ b/include/boost/astronomy/io/column_data.hpp
@@ -1,0 +1,29 @@
+#ifndef BOOST_ASTRONOMY_IO_COLUMN_DATA_HPP
+#define BOOST_ASTRONOMY_IO_COLUMN_DATA_HPP
+
+#include <string>
+#include <cstddef>
+#include <vector>
+
+#include <boost/static_assert.hpp>
+
+#include <boost/astronomy/io/column.hpp>
+
+namespace boost { namespace astronomy { namespace io {
+
+template <typename Type>
+struct column_data: public column
+{
+private:
+    std::vector<Type> column_data_;
+
+public:
+    std::vector<Type> get_data() const
+    {
+        return column_data_;
+    }
+};
+
+}}}
+
+#endif // !BOOST_ASTRONOMY_IO_COLUMN_DATA_HPP

--- a/include/boost/astronomy/io/extension_hdu.hpp
+++ b/include/boost/astronomy/io/extension_hdu.hpp
@@ -13,6 +13,7 @@ namespace boost { namespace astronomy { namespace io {
 struct extension_hdu : public boost::astronomy::io::hdu
 {
 protected:
+    std::string extname;
     int gcount = 1;
     int pcount = 0;
 
@@ -23,18 +24,21 @@ public:
     {
         gcount = this->value_of<int>("GCOUNT");
         pcount = this->value_of<int>("PCOUNT");
+        extname = this->value_of<std::string>("EXTNAME");
     }
 
     extension_hdu(std::fstream &file, hdu const& other) : hdu(other)
     {
         gcount = this->value_of<int>("GCOUNT");
         pcount = this->value_of<int>("PCOUNT");
+        extname = this->value_of<std::string>("EXTNAME");
     }
 
     extension_hdu(std::fstream &file, std::streampos pos) : hdu(file, pos)
     {
         gcount = this->value_of<int>("GCOUNT");
         pcount = this->value_of<int>("PCOUNT");
+        extname = this->value_of<std::string>("EXTNAME");
     }
 };
 

--- a/include/boost/astronomy/io/hdu.hpp
+++ b/include/boost/astronomy/io/hdu.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include <unordered_map>
+#include <memory>
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
@@ -14,8 +15,12 @@
 #include <boost/astronomy/io/image.hpp>
 #include <boost/astronomy/exception/fits_exception.hpp>
 #include <boost/astronomy/io/card.hpp>
+#include <boost/astronomy/io/column.hpp>
 
 namespace boost { namespace astronomy { namespace io {
+
+struct column;
+
 struct hdu
 {
 protected:
@@ -150,6 +155,11 @@ public:
     {
         //set cursor to the end of the HDU unit
         file.seekg((file.tellg() + (2880 - (file.tellg() % 2880))));    
+    }
+
+    virtual std::unique_ptr<column> get_column(std::string name) const
+    {
+        throw wrong_extension_type();
     }
 };
 }}} //namespace boost::astronomy::io

--- a/include/boost/astronomy/io/table_extension.hpp
+++ b/include/boost/astronomy/io/table_extension.hpp
@@ -1,0 +1,43 @@
+#ifndef BOOST_ASTRONOMY_IO_TABLE_EXTENSION_HPP
+#define BOOST_ASTRONOMY_IO_TABLE_EXTENSION_HPP
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <boost/astronomy/io/extension_hdu.hpp>
+#include <boost/astronomy/io/column.hpp>
+
+namespace boost { namespace astronomy { namespace io {
+
+
+struct table_extension : public extension_hdu
+{
+protected:
+    std::size_t tfields;
+    std::vector<column> col_metadata;
+    std::vector<char> data;
+
+public:
+    table_extension() {}
+
+    table_extension(std::fstream &file) : extension_hdu(file)
+    {
+        tfields = this->value_of<std::size_t>("TFIELDS");
+        col_metadata.reserve(tfields);
+    }
+
+    table_extension(std::fstream &file, hdu const& other) : extension_hdu(file, other)
+    {
+        tfields = this->value_of<std::size_t>("TFIELDS");
+        col_metadata.reserve(tfields);
+    }
+
+    table_extension(std::fstream &file, std::streampos pos) : extension_hdu(file, pos)
+    {
+        tfields = this->value_of<std::size_t>("TFIELDS");
+        col_metadata.reserve(tfields);
+    }
+};
+
+}}} //namespace boost::astronomy::io
+#endif // !BOOST_ASTRONOMY_IO_TABLE_EXTENSION


### PR DESCRIPTION

### Description
`table_extension` is the base class for `binary_table` and `ascii_table` classes.

`column` and `column_data` classes are supporting classes to access table data easily. 
<!-- What does this pull request do? -->

### References
closes #67
<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Ensure all CI builds pass
- [x] Review and approve
