### PR TITLE
Update arithmetic.hpp to extend unit_vector to non-Cartesian representation

### DIFF
--- a/include/boost/astronomy/coordinate/arithmetic.hpp
+++ b/include/boost/astronomy/coordinate/arithmetic.hpp
@@ -239,6 +239,19 @@ unit_vector(cartesian_representation<Args...> const& vector)
     return cartesian_representation<Args...>(tempPoint);
 }
 
+//! Returns unit vector of given vector other than Cartesian
+template <typename Coordinate>
+auto unit_vector(Coordinate const& vector)
+{
+    Coordinate tempVector;
+
+    tempVector.set_lat(vector.get_lat());
+    tempVector.set_lon(vector.get_lon());
+    tempVector.set_dist(1.0 * typename Coordinate::quantity3::unit_type());
+
+    return tempVector;
+}
+
 
 //! Returns sum of representation1 and representation2 
 template<typename Representation1, typename Representation2>

--- a/test/coordinate/spherical_equatorial_representation.cpp
+++ b/test/coordinate/spherical_equatorial_representation.cpp
@@ -230,21 +230,21 @@ BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_dot_product)
         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
 }
 
-// BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_unit_vector)
-// {
-//     auto point1 = make_spherical_equatorial_representation(25.0 * bud::degrees, 30.0 * bud::degrees, 90.0*meter);
+BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_unit_vector)
+{
+    auto point1 = make_spherical_equatorial_representation(25.0 * bud::degrees, 30.0 * bud::degrees, 90.0*meter);
 
-//     auto result = boost::astronomy::coordinate::unit_vector(point1);
+    auto result = boost::astronomy::coordinate::unit_vector(point1);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), 25.0, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 30.0, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 1, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), 25.0, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 30.0, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 1, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity<si::length>>::value));
-// }
+    //checking whether quantity stored is as expected or not
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity<si::length>>::value));
+}
 
 BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_magnitude)
 {

--- a/test/coordinate/spherical_representation.cpp
+++ b/test/coordinate/spherical_representation.cpp
@@ -230,21 +230,21 @@ BOOST_AUTO_TEST_CASE(spherical_representation_dot_product)
         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
 }
 
-// BOOST_AUTO_TEST_CASE(spherical_representation_unit_vector)
-// {
-//     auto point1 = make_spherical_representation(25.0 * bud::degrees, 30.0 * bud::degrees, 90.0*meter);
+BOOST_AUTO_TEST_CASE(spherical_representation_unit_vector)
+{
+    auto point1 = make_spherical_representation(25.0 * bud::degrees, 30.0 * bud::degrees, 90.0*meter);
 
-//     auto result = boost::astronomy::coordinate::unit_vector(point1);
+    auto result = boost::astronomy::coordinate::unit_vector(point1);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), 25.0, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 30.0, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 1, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), 25.0, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 30.0, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 1, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity<si::length>>::value));
-// }
+    //checking whether quantity stored is as expected or not
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity<si::length>>::value));
+}
 
 BOOST_AUTO_TEST_CASE(spherical_representation_magnitude)
 {


### PR DESCRIPTION


<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Updated arithmetic.hpp to generalize unit_vector function for all representations. Previously it was wriiten only for Cartesian.


