### PR TITLE
Added header io.hpp to overload << operator to print points.

### DIFF
--- a/include/boost/astronomy/coordinate/io.hpp
+++ b/include/boost/astronomy/coordinate/io.hpp
@@ -1,0 +1,63 @@
+#ifndef BOOST_ASTRONOMY_COORDINATE_IO_HPP
+#define BOOST_ASTRONOMY_COORDINATE_IO_HPP
+
+//! Header to facilitate priting of coordinates of a point with units.
+
+#include <iostream>
+
+#include <boost/units/quantity.hpp>
+#include <boost/units/io.hpp>
+
+#include <boost/astronomy/coordinate/cartesian_representation.hpp>
+#include <boost/astronomy/coordinate/spherical_representation.hpp>
+#include <boost/astronomy/coordinate/spherical_equatorial_representation.hpp>
+
+namespace boost { namespace astronomy { namespace coordinate {
+
+//!"<<" operator overload to print details of a Cartesian point
+template
+<
+    typename CoordinateType,
+    class XQuantity,
+    class YQuantity,
+    class ZQuantity
+>
+std::ostream& operator<< (std::ostream &out, cartesian_representation< CoordinateType, XQuantity, YQuantity, ZQuantity> const& point)
+{
+    out << "Cartesian Representation ( " << point.get_x() << " , " << point.get_y() << " , " << point.get_x() << " )";
+
+    return out;
+}
+
+//!"<<" operator overload to print details of a Spherical Equatorial Point
+template
+<
+    typename CoordinateType,
+    class LatQuantity,
+    class LonQuantity,
+    class DistQuantity
+>
+std::ostream& operator<< (std::ostream &out, spherical_equatorial_representation< CoordinateType, LatQuantity, LonQuantity, DistQuantity> const& point)
+{
+    out << "Spherical Equatorial Representation ( " << point.get_lat() << " , " << point.get_lon() << " , " << point.get_dist() << " )";
+
+    return out;
+}
+
+//!"<<" operator overload to print details of a Spherical point
+template
+<
+    typename CoordinateType,
+    class LatQuantity,
+    class LonQuantity,
+    class DistQuantity
+>
+std::ostream& operator<< (std::ostream &out, spherical_representation< CoordinateType, LatQuantity, LonQuantity, DistQuantity> const& point)
+{
+    out << "Spherical Representation ( " << point.get_lat() << " , " << point.get_lon() << " , " << point.get_dist() << " )";
+
+    return out;
+}
+
+}}} //namespace boost::astronomy::coordinate
+#endif // !BOOST_ASTRONOMY_COORDINATE_IO_HPP


### PR DESCRIPTION
### Description
Overloaded << operator to print points.
Chaining of << operators is also supported.
Example : 
```c++
auto point1 = make_cartesian_representation(1.0 * meters, 2.0 * meters, 3.0 * meters);
auto point2 = make_spherical_representation(45.0 * bud::degrees, 45.0 * bud::degrees, 1.0 * meters);
auto point3 = make_spherical_equatorial_representation(45.0 * bud::degrees, 45.0 * bud::degrees, 1.0 * meters);
std::cout << point1 << "\n" << point2 << "\n" << point3;
```
This code will generate an output :
```
Cartesian Representation ( 1 m , 2 m , 1 m )
Spherical Representation ( 45 deg , 45 deg , 1 m )
Spherical Equatorial Representation ( 45 deg , 45 deg , 1 m )
```
