### PR TITLE
Update Arithmetic.hpp to fix bug in return units of cross function

### DIFF
--- a/test/coordinate/cartesian_representation.cpp
+++ b/test/coordinate/cartesian_representation.cpp
@@ -208,18 +208,17 @@ BOOST_AUTO_TEST_CASE(cartesian_representation_cross_product)
 
     auto result = cross(point1, point2);
 
-    BOOST_CHECK_CLOSE(result.get_x().value(), -180.0, 0.001);
-    BOOST_CHECK_CLOSE(result.get_y().value(), 11.988, 0.001);
-    BOOST_CHECK_CLOSE(result.get_z().value(), -1485.0, 0.001);
+    BOOST_CHECK_CLOSE(result.get_x().value(), -1.8e+08, 0.001);
+    BOOST_CHECK_CLOSE(result.get_y().value(), 1.1988e+07, 0.001);
+    BOOST_CHECK_CLOSE(result.get_z().value(), -14850, 0.001);
 
     //checking whether quantity stored is as expected or not
     BOOST_TEST((std::is_same<decltype(result.get_x()), quantity
-        <bu::multiply_typeof_helper<decltype(si::kilo*meters), si::length>::type>>::value));
+        <bu::multiply_typeof_helper<si::length,decltype(si::milli*meters)>::type>>::value));
     BOOST_TEST((std::is_same<decltype(result.get_y()), quantity
-        <bu::multiply_typeof_helper<decltype(si::mega*meters),
-        decltype(si::milli*meters)>::type>>::value));
+        <bu::multiply_typeof_helper<si::length,decltype(si::milli*meters)>::type>>::value));
     BOOST_TEST((std::is_same<decltype(result.get_z()), quantity
-        <bu::multiply_typeof_helper<decltype(si::centi*meters), si::length>::type>>::value));
+        <bu::multiply_typeof_helper<si::length,decltype(si::milli*meters)>::type>>::value));
 }
 
 BOOST_AUTO_TEST_CASE(cartesian_representation_dot_product)

--- a/test/coordinate/spherical_equatorial_representation.cpp
+++ b/test/coordinate/spherical_equatorial_representation.cpp
@@ -196,25 +196,23 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(spherical_equatorial_representation_arithmetic_functions)
 
-// BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_cross_product)
-// {
-//     auto point1 = make_spherical_equatorial_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
-//     auto point2 = make_spherical_equatorial_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
+BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_cross_product)
+{
+    auto point1 = make_spherical_equatorial_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
+    auto point2 = make_spherical_equatorial_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
 
-//     auto result = cross(point1, point2);
+    auto result = cross(point1, point2);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), -143.4774246228, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 45.186034054587, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 195.39050840581, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), 3.08011, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 0.694936, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 180.459, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-// }
+    //checking whether quantity stored is as expected or not
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bu::si::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bu::si::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
+        <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
+}
 
 BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_dot_product)
 {

--- a/test/coordinate/spherical_representation.cpp
+++ b/test/coordinate/spherical_representation.cpp
@@ -196,25 +196,23 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(spherical_representation_arithmetic_functions)
 
-// BOOST_AUTO_TEST_CASE(spherical_representation_cross_product)
-// {
-//     auto point1 = make_spherical_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
-//     auto point2 = make_spherical_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
+BOOST_AUTO_TEST_CASE(spherical_representation_cross_product)
+{
+    auto point1 = make_spherical_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
+    auto point2 = make_spherical_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
 
-//     auto result = cross(point1, point2);
+    auto result = cross(point1, point2);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), -143.4774246228, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 45.186034054587, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 195.39050840581, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), -2.50415, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 0.788645, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 195.391, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-// }
+    //checking whether quantity stored is as expected or not
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bu::si::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bu::si::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
+        <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
+}
 
 BOOST_AUTO_TEST_CASE(spherical_representation_dot_product)
 {


### PR DESCRIPTION
### Description

Previously, wrong units were generated for cross function for any combination apart from both Cartesian. That bug has been fixed.

1. A separate function overload has been made to deal with cases where `cartesian` is not first argument.
2. Few mistakes in the tests for `spherical` and `spherical_equatorial` have been fixed too. 

closes #79 .
