### PR TITLE
bug fix of cross function in arithmetic.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@
 /astronomy.vcxproj
 /astronomy.sln
 *.user
+*.project
 /ClassDiagram.cd
 

--- a/include/boost/astronomy/coordinate/arithmetic.hpp
+++ b/include/boost/astronomy/coordinate/arithmetic.hpp
@@ -13,6 +13,8 @@
 
 #include <boost/astronomy/coordinate/base_representation.hpp>
 #include <boost/astronomy/coordinate/cartesian_representation.hpp>
+#include <boost/astronomy/coordinate/representation.hpp>
+#include <boost/astronomy/coordinate/differential.hpp>
 
 
 namespace boost { namespace astronomy { namespace coordinate {
@@ -20,8 +22,115 @@ namespace boost { namespace astronomy { namespace coordinate {
 namespace bg = boost::geometry;
 namespace bu = boost::units;
 
+//!Returns the cross product of cartesian_representation(representation1) and representation2
+template
+<
+    template<typename ...> class Representation2,
+    typename ...Args1,
+    typename ...Args2
+>
+auto cross
+(
+    cartesian_representation<Args1...> const& representation1,
+    Representation2<Args2...> const& representation2
+)
+{
+    /*!both the coordinates/vector are first converted into
+    cartesian coordinate system then cross product of both cartesian
+    vectors is converted into cartesian system type and returned*/
 
-//!Returns the cross product of representation1 and representation2
+    /*checking types if it is not subclass of   
+    base_representaion then compile time erorr is generated*/
+    //BOOST_STATIC_ASSERT_MSG((boost::astronomy::detail::is_base_template_of
+    //    <
+    //        boost::astronomy::coordinate::base_representation,
+    //        Representation1<Args1...>
+    //    >::value),
+    //    "First argument type is expected to be a representation class");
+    //BOOST_STATIC_ASSERT_MSG((boost::astronomy::detail::is_base_template_of
+    //    <
+    //        boost::astronomy::coordinate::base_representation,
+    //        Representation2<Args2...>
+    //    >::value),
+    //    "Second argument type is expected to be a representation class");
+
+    /*converting both coordinates/vector into cartesian system*/
+
+    typedef cartesian_representation<Args1...> representation1_type;
+    typedef Representation2<Args2...> representation2_type;
+
+    bg::model::point
+    <
+        typename std::conditional
+        <
+            sizeof(typename representation2_type::type) >=
+                sizeof(typename representation1_type::type),
+            typename representation2_type::type,
+            typename representation1_type::type
+        >::type,
+        3,
+        bg::cs::cartesian
+    > tempPoint1, tempPoint2, result;
+
+    auto cartesian1 = representation1;
+    auto cartesian2 = make_cartesian_representation(representation2);
+
+    typedef decltype(cartesian1) cartesian1_type;
+    typedef decltype(cartesian2) cartesian2_type;
+    
+
+    bg::transform(representation1.get_point(), tempPoint1);
+    bg::transform(representation2.get_point(), tempPoint2);
+    
+
+    bg::set<0>(result, (bg::get<1>(tempPoint1)*bg::get<2>(tempPoint2)) -
+        ((bg::get<2>(tempPoint1)*
+        bu::conversion_factor(typename cartesian1_type::quantity3::unit_type(),
+        typename cartesian1_type::quantity2::unit_type()))*
+        (bg::get<1>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity2::unit_type(),
+        typename cartesian2_type::quantity3::unit_type()))));
+
+    bg::set<1>(result, (bg::get<2>(tempPoint1)*bg::get<0>(tempPoint2)) -
+        ((bg::get<0>(tempPoint1)*
+        bu::conversion_factor(typename cartesian1_type::quantity1::unit_type(),
+        typename cartesian1_type::quantity3::unit_type()))*
+        (bg::get<2>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity3::unit_type(),
+        typename cartesian2_type::quantity1::unit_type()))));
+
+    bg::set<2>(result, (bg::get<0>(tempPoint1)*bg::get<1>(tempPoint2)) -
+        ((bg::get<1>(tempPoint1)*
+        bu::conversion_factor(typename cartesian1_type::quantity2::unit_type(),
+        typename cartesian1_type::quantity1::unit_type()))*
+        (bg::get<0>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity1::unit_type(),
+        typename cartesian2_type::quantity2::unit_type()))));
+
+
+    return 
+        cartesian_representation
+        <
+            typename cartesian1_type::type,
+            bu::quantity<typename bu::multiply_typeof_helper
+            <
+                typename cartesian1_type::quantity2::unit_type,
+                typename cartesian2_type::quantity3::unit_type>::type
+            >,
+            bu::quantity<typename bu::multiply_typeof_helper
+            <
+                typename cartesian1_type::quantity3::unit_type,
+                typename cartesian2_type::quantity1::unit_type>::type
+            >,
+            bu::quantity<typename bu::multiply_typeof_helper
+            <
+                typename cartesian1_type::quantity1::unit_type,
+                typename cartesian2_type::quantity2::unit_type>::type
+            >
+        >(result);
+}
+
+//!Returns the cross product of representation1(other than cartesian form) and representation2
 template
 <
     template<typename ...> class Representation1,
@@ -37,9 +146,9 @@ auto cross
 {
     /*!both the coordinates/vector are first converted into
     cartesian coordinate system then cross product of both cartesian
-    vectors is converted into requested type and returned*/
+    vectors is converted into requested system type and returned*/
 
-    /*checking types if it is not subclass of
+    /*checking types if it is not subclass of   
     base_representaion then compile time erorr is generated*/
     //BOOST_STATIC_ASSERT_MSG((boost::astronomy::detail::is_base_template_of
     //    <
@@ -72,52 +181,50 @@ auto cross
         bg::cs::cartesian
     > tempPoint1, tempPoint2, result;
 
-    bg::transform(representation1.get_point(), tempPoint1);
-    bg::transform(representation2.get_point(), tempPoint2);
+    auto cartesian1 = make_cartesian_representation(representation1);
+    auto cartesian2 = make_cartesian_representation(representation2);
+    
+    typedef decltype(cartesian1) cartesian1_type;
+    typedef decltype(cartesian2) cartesian2_type;
+    
 
-    bg::set<0>(result, (bg::get<1>(tempPoint1)*bg::get<2>(tempPoint2)) -
-        ((bg::get<2>(tempPoint1)*
-        bu::conversion_factor(typename representation1_type::quantity3::unit_type(),
-        typename representation1_type::quantity2::unit_type()))*
-        (bg::get<1>(tempPoint2)*
-        bu::conversion_factor(typename representation2_type::quantity2::unit_type(),
-        typename representation2_type::quantity3::unit_type()))));
-
-    bg::set<1>(result, (bg::get<2>(tempPoint1)*bg::get<0>(tempPoint2)) -
-        ((bg::get<0>(tempPoint1)*
-        bu::conversion_factor(typename representation1_type::quantity1::unit_type(),
-        typename representation1_type::quantity3::unit_type()))*
-        (bg::get<2>(tempPoint2)*
-        bu::conversion_factor(typename representation2_type::quantity3::unit_type(),
-        typename representation2_type::quantity1::unit_type()))));
-
-    bg::set<2>(result, (bg::get<0>(tempPoint1)*bg::get<1>(tempPoint2)) -
-        ((bg::get<1>(tempPoint1)*
-        bu::conversion_factor(typename representation1_type::quantity2::unit_type(),
-        typename representation1_type::quantity1::unit_type()))*
-        (bg::get<0>(tempPoint2)*
-        bu::conversion_factor(typename representation2_type::quantity1::unit_type(),
-        typename representation2_type::quantity2::unit_type()))));
+    bg::transform(cartesian1.get_point(), tempPoint1);
+    bg::transform(cartesian2.get_point(), tempPoint2);
+    
+    
+    bg::set<0>(
+        tempPoint2,
+        bg::get<0>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity1::unit_type(),
+        typename cartesian2_type::quantity1::unit_type())
+    );
+    bg::set<1>(
+        tempPoint2,
+        bg::get<1>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity2::unit_type(),
+        typename cartesian2_type::quantity1::unit_type())
+    );
+    bg::set<2>(
+        tempPoint2,
+        bg::get<2>(tempPoint2)*
+        bu::conversion_factor(typename cartesian2_type::quantity3::unit_type(),
+        typename cartesian2_type::quantity1::unit_type())
+    );
+    
+    result = bg::cross_product(tempPoint1,tempPoint2);
 
     return Representation1
         <
             typename representation1_type::type,
+            typename representation1_type::quantity1,
+            typename representation1_type::quantity2,
             bu::quantity<typename bu::multiply_typeof_helper
-            <
-                typename representation1_type::quantity2::unit_type,
-                typename representation2_type::quantity3::unit_type>::type
-            >,
-            bu::quantity<typename bu::multiply_typeof_helper
-            <
-                typename representation1_type::quantity3::unit_type,
-                typename representation2_type::quantity1::unit_type>::type
-            >,
-            bu::quantity<typename bu::multiply_typeof_helper
-            <
-                typename representation1_type::quantity1::unit_type,
-                typename representation2_type::quantity2::unit_type>::type
-            >
+                <
+                    typename cartesian1_type::quantity1::unit_type,
+                    typename cartesian2_type::quantity1::unit_type>::type
+                >
         >(result);
+
 }
 
 

--- a/test/coordinate/spherical_equatorial_representation.cpp
+++ b/test/coordinate/spherical_equatorial_representation.cpp
@@ -196,25 +196,23 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(spherical_equatorial_representation_arithmetic_functions)
 
-// BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_cross_product)
-// {
-//     auto point1 = make_spherical_equatorial_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
-//     auto point2 = make_spherical_equatorial_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
+BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_cross_product)
+{
+    auto point1 = make_spherical_equatorial_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
+    auto point2 = make_spherical_equatorial_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
 
-//     auto result = cross(point1, point2);
+    auto result = cross(point1, point2);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), -143.4774246228, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 45.186034054587, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 195.39050840581, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), 176.47742460814121, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 39.816895281423861, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 180.459280550626, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-// }
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
+        <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
+}
+
 
 BOOST_AUTO_TEST_CASE(spherical_equatorial_representation_dot_product)
 {

--- a/test/coordinate/spherical_representation.cpp
+++ b/test/coordinate/spherical_representation.cpp
@@ -196,25 +196,22 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(spherical_representation_arithmetic_functions)
 
-// BOOST_AUTO_TEST_CASE(spherical_representation_cross_product)
-// {
-//     auto point1 = make_spherical_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
-//     auto point2 = make_spherical_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
+BOOST_AUTO_TEST_CASE(spherical_representation_cross_product)
+{
+    auto point1 = make_spherical_representation(3.0 * bud::degrees, 50.0 * bud::degrees, 40.0 * meters);
+    auto point2 = make_spherical_representation(30.0 * bud::degrees, 45.0 * bud::degrees, 14.0 * meters);
 
-//     auto result = cross(point1, point2);
+    auto result = cross(point1, point2);
 
-//     BOOST_CHECK_CLOSE(result.get_lat().value(), -143.4774246228, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_lon().value(), 45.186034054587, 0.001);
-//     BOOST_CHECK_CLOSE(result.get_dist().value(), 195.39050840581, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lat().value(), -143.4774246228, 0.001);
+    BOOST_CHECK_CLOSE(result.get_lon().value(), 45.186034054587, 0.001);
+    BOOST_CHECK_CLOSE(result.get_dist().value(), 195.39050840581, 0.001);
 
-//     //checking whether quantity stored is as expected or not
-//     BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-//     BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
-//         <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
-// }
+    BOOST_TEST((std::is_same<decltype(result.get_lat()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_lon()), quantity<bud::plane_angle>>::value));
+    BOOST_TEST((std::is_same<decltype(result.get_dist()), quantity
+            <bu::multiply_typeof_helper<si::length, si::length>::type>>::value));
+}
 
 BOOST_AUTO_TEST_CASE(spherical_representation_dot_product)
 {


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
1. Previously, cross generate errors for some coordinate system i.e previous version can't able to identify bu::conversion_factor(plane_angle, meter for cross_product(cartesian point, spherical point) ) in calculation part of code.
2. Now cross returns cross product in requested representation( It returns correct units for every representation).
3. Updated tests for cross product.

<!-- What does this pull request do? -->

### References
Fixes #79 
<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [x] Add test case(s)
- [x] Ensure all CI builds pass
- [x] Review and approve
