### PR TITLE
AzP macOS-10.13 and vs2015-win2012r2 images are removed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
           LLVM_REPO: llvm-toolchain-xenial-5.0
         Clang 4:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17
+          B2_CXXSTD: 14
           CXX: clang++-4.0
           PACKAGES: clang-4.0
           LLVM_REPO: llvm-toolchain-xenial-4.0
@@ -160,11 +160,6 @@ stages:
           #B2_CXXSTD: 14 # default
           B2_ADDRESS_MODEL: address-model=64,32
           VM_IMAGE: 'vs2017-win2016'
-        VS 2015 C++14:
-          B2_TOOLSET: msvc-14.0
-          #B2_CXXSTD: 14 # default
-          B2_ADDRESS_MODEL: address-model=64,32
-          VM_IMAGE: 'vs2015-win2012r2'
 
     pool:
       vmImage: $(VM_IMAGE)
@@ -192,37 +187,45 @@ stages:
 
   - job: 'macOS'
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     strategy:
       matrix:
-        Xcode 10.1:
+        Xcode_11_3_1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.3.1.app
+        Xcode_11_2_1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.2.1.app
+        Xcode_11_2:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.2.app
+        Xcode_11_1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.1.app
+        Xcode_10_3:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.3.app
+        Xcode_10_2_1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.2.1.app
+        Xcode_10_2:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.2.app
+        Xcode_10_1:
           B2_TOOLSET: clang
           B2_CXXSTD: 14,17,2a
           XCODE_APP: /Applications/Xcode_10.1.app
-        Xcode 10.0:
+        Xcode_10_0:
           B2_TOOLSET: clang
           B2_CXXSTD: 14,17,2a
           XCODE_APP: /Applications/Xcode_10.app
-        Xcode 9.4.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 14,17
-          XCODE_APP: /Applications/Xcode_9.4.1.app
-        Xcode 9.4:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 14,17
-          XCODE_APP: /Applications/Xcode_9.4.app
-        Xcode 9.3.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 14,17
-          XCODE_APP: /Applications/Xcode_9.3.1.app
-        Xcode 9.3:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 14
-          XCODE_APP: /Applications/Xcode_9.3.app
-        Xcode 9.2:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 14
-          XCODE_APP: /Applications/Xcode_9.2.app
     steps:
     - bash: |
         set -e


### PR DESCRIPTION
### Description
Removed jobs on macOs-10.13 and VS2015 from azure-pipeline as they are not supported anymore.

### References
closes #122

### Tasklist
- [x] Ensure all CI builds pass
- [x] Review and approve