### PR TITLE
overload ==operator in coordinate systems

### DIFF
--- a/include/boost/astronomy/coordinate/cartesian_representation.hpp
+++ b/include/boost/astronomy/coordinate/cartesian_representation.hpp
@@ -14,6 +14,8 @@
 #include <boost/units/get_dimension.hpp>
 #include <boost/units/systems/si/dimensionless.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_representation.hpp>
 
@@ -205,6 +207,29 @@ public:
         >(result);
     }
 
+    //!"==" operator to compare with other representations
+    template
+    <typename Representation>
+    bool operator ==(Representation const& other) const
+    {
+        auto tempRep1 = make_cartesian_representation(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<XQuantity>(tempRep1.get_x()).value(),
+            this->get_x().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<YQuantity>(tempRep1.get_y()).value(),
+            this->get_y().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<ZQuantity>(tempRep1.get_z()).value(),
+            this->get_z().value());
+    }
 }; //cartesian_representation
 
 

--- a/include/boost/astronomy/coordinate/spherical_coslat_differential.hpp
+++ b/include/boost/astronomy/coordinate/spherical_coslat_differential.hpp
@@ -16,6 +16,8 @@
 #include <boost/units/systems/si/dimensionless.hpp>
 #include <boost/units/systems/si/plane_angle.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_differential.hpp>
 #include <boost/astronomy/coordinate/cartesian_differential.hpp>
@@ -255,6 +257,28 @@ public:
         );
 
         return product;
+    }
+
+    //!"==" operator to compare with other differentials
+    template
+    <typename Differential>
+    bool operator ==(Differential const& other) const
+    {
+        auto tempRep1 = make_spherical_coslat_differential(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LatQuantity>(tempRep1.get_dlat()).value(),this->get_dlat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LonQuantity>(tempRep1.get_dlon_coslat()).value(),
+            this->get_dlon_coslat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<DistQuantity>(tempRep1.get_ddist()).value(),this->get_ddist().value());
     }
 }; //spherical_coslat_differential
 

--- a/include/boost/astronomy/coordinate/spherical_differential.hpp
+++ b/include/boost/astronomy/coordinate/spherical_differential.hpp
@@ -15,6 +15,8 @@
 #include <boost/units/systems/si/dimensionless.hpp>
 #include <boost/units/systems/si/plane_angle.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_differential.hpp>
 #include <boost/astronomy/coordinate/cartesian_differential.hpp>
@@ -248,6 +250,30 @@ public:
         );
 
         return product;
+    }
+
+    //!"==" operator to compare with other differentials
+    template
+    <typename Differential>
+    bool operator ==(Differential const& other) const
+    {
+        auto tempRep1 = make_spherical_differential(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LatQuantity>(tempRep1.get_dlat()).value(),
+            this->get_dlat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LonQuantity>(tempRep1.get_dlon()).value(),
+            this->get_dlon().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<DistQuantity>(tempRep1.get_ddist()).value(),
+            this->get_ddist().value());
     }
 }; //spherical_differential
 

--- a/include/boost/astronomy/coordinate/spherical_equatorial_differential.hpp
+++ b/include/boost/astronomy/coordinate/spherical_equatorial_differential.hpp
@@ -15,6 +15,8 @@
 #include <boost/units/systems/si/dimensionless.hpp>
 #include <boost/units/systems/si/plane_angle.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_differential.hpp>
 #include <boost/astronomy/coordinate/cartesian_differential.hpp>
@@ -248,6 +250,30 @@ public:
         );
 
         return product;
+    }
+
+    //!"==" operator to compare with other differentials
+    template
+    <typename Differential>
+    bool operator ==(Differential const& other) const
+    {
+        auto tempRep1 = make_spherical_equatorial_differential(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LatQuantity>(tempRep1.get_dlat()).value(),
+            this->get_dlat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LonQuantity>(tempRep1.get_dlon()).value(),
+            this->get_dlon().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<DistQuantity>(tempRep1.get_ddist()).value(),
+            this->get_ddist().value());
     }
 }; //spherical_equatorial_differential
 

--- a/include/boost/astronomy/coordinate/spherical_equatorial_representation.hpp
+++ b/include/boost/astronomy/coordinate/spherical_equatorial_representation.hpp
@@ -15,6 +15,8 @@
 #include <boost/units/get_dimension.hpp>
 #include <boost/units/systems/si/dimensionless.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_representation.hpp>
 #include <boost/astronomy/coordinate/cartesian_representation.hpp>
@@ -227,6 +229,29 @@ public:
         return result;
     }
 
+    //!"==" operator to compare with other representations
+    template
+    <typename Representation>
+    bool operator ==(Representation const& other) const
+    {
+        auto tempRep1 = make_spherical_equatorial_representation(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LatQuantity>(tempRep1.get_lat()).value(),
+            this->get_lat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LonQuantity>(tempRep1.get_lon()).value(),
+            this->get_lon().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<DistQuantity>(tempRep1.get_dist()).value(),
+            this->get_dist().value());
+    }
 }; //spherical_equatorial_representation
 
 

--- a/include/boost/astronomy/coordinate/spherical_representation.hpp
+++ b/include/boost/astronomy/coordinate/spherical_representation.hpp
@@ -14,6 +14,8 @@
 #include <boost/units/systems/si/plane_angle.hpp>
 #include <boost/units/systems/si/dimensionless.hpp>
 
+#include <boost/test/tools/floating_point_comparison.hpp>
+
 #include <boost/astronomy/detail/is_base_template_of.hpp>
 #include <boost/astronomy/coordinate/base_representation.hpp>
 #include <boost/astronomy/coordinate/cartesian_representation.hpp>
@@ -204,6 +206,7 @@ public:
         bg::set<2>(this->point, distance.value());
     }
 
+    //!"+" operator to add any other representations
     template<typename Addend>
     spherical_representation
     <
@@ -233,6 +236,29 @@ public:
         return result;
     }
 
+    //!"==" operator to compare with other representations
+    template
+    <typename Representation>
+    bool operator ==(Representation const& other) const
+    {
+        auto tempRep1 = make_spherical_representation(other);
+        
+        return 
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LatQuantity>(tempRep1.get_lat()).value(),
+            this->get_lat().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<LonQuantity>(tempRep1.get_lon()).value(),
+            this->get_lon().value())
+        &&
+        boost::math::fpc::close_at_tolerance<CoordinateType>
+            (boost::math::fpc::percent_tolerance(1e-10),boost::math::fpc::FPC_STRONG)
+            (static_cast<DistQuantity>(tempRep1.get_dist()).value(),
+            this->get_dist().value());
+    }
 }; //spherical_representation
 
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description
Previously wrong results are generating with `==` operator in case of representations and differentials. Now it has been fixed. (we can compare two differentials or representations up to a tolerance of **1e-10**.)
<!-- What does this pull request do? -->

### References
Fixes #133 
<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist
