### PR TITLE
Added support for caching in card ( variant and type sequence )

### DIFF
--- a/include/boost/astronomy/io/default_card_policy.hpp
+++ b/include/boost/astronomy/io/default_card_policy.hpp
@@ -17,6 +17,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 #include <boost/astronomy/exception/fits_exception.hpp>
 #include <boost/astronomy/io/string_conversion_utility.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/mpl/vector.hpp>
 
 namespace boost{namespace astronomy{namespace io{
 
@@ -25,6 +26,22 @@ class card_policy {
     std::vector<std::string> reserved_keywords;
 
 public:
+    typedef boost::mpl::vector<
+        boost::blank,
+        bool,
+        int,
+        float,
+        double,
+        unsigned int,
+        long long,
+        std::size_t,
+        std::string,
+        std::complex<int>,
+        std::complex<double>,
+        std::complex<float>,
+        std::complex<std::size_t>
+    >  supported_types;
+
 
     /**
      * @brief Constructs a default object of card and initializes the reserved keyword list


### PR DESCRIPTION
Querying a card value always involved parsing the card data again and again according to type causing performance problems. Now a cache has been added to the card type which caches the value once and upon subsequent queries returns the parsed value from the cache.

Also the list of supported types in cache can be changed through the policy.  The card policy should expose a typedef named **supported_types** which is a type sequence **boost::mpl::vector<>**. The card automatically figures out the types supported from supported types in card policy