### PR TITLE
Replaced spirit based ASCII converter with lexical_cast based ASCII converter

### DIFF
--- a/include/boost/astronomy/io/default_card_policy.hpp
+++ b/include/boost/astronomy/io/default_card_policy.hpp
@@ -17,6 +17,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 #include <boost/astronomy/exception/fits_exception.hpp>
 #include <boost/astronomy/io/string_conversion_utility.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/blank.hpp>
 #include <boost/mpl/vector.hpp>
 
 namespace boost{namespace astronomy{namespace io{

--- a/include/boost/astronomy/io/string_conversion_utility.hpp
+++ b/include/boost/astronomy/io/string_conversion_utility.hpp
@@ -9,8 +9,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_ASTRONOMY_IO_STRING_CONVERSION_UTILITY_HPP
 
 #include <sstream>
-#include <boost/spirit/include/qi.hpp>
-#include <boost/type.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/astronomy/exception/fits_exception.hpp>
 
 
@@ -21,15 +20,6 @@ namespace boost{namespace astronomy{namespace io{
      * @brief Used for serialization and deserialization of ASCII table's data
     */
     struct ascii_converter {
-    private:
-       static boost::spirit::qi::int_type spirit_type(boost::type<int>) { return boost::spirit::qi::int_; }
-       static boost::spirit::qi::uint_type spirit_type(boost::type<unsigned int>) { return boost::spirit::qi::uint_; }
-       static boost::spirit::qi::float_type spirit_type(boost::type<float>) { return boost::spirit::qi::float_; }
-       static boost::spirit::qi::double_type spirit_type(boost::type<double>) { return boost::spirit::qi::double_; }
-       static boost::spirit::qi::long_long_type spirit_type(boost::type<long long>) { return boost::spirit::qi::long_long; }
-       static boost::spirit::qi::ulong_long_type spirit_type(boost::type<long unsigned int>) { return boost::spirit::qi::ulong_long; }
-       static boost::spirit::qi::ulong_long_type spirit_type(boost::type<unsigned long long>) { return boost::spirit::qi::ulong_long; }
-    public:
 
         /**
          * @brief Deserializes the ASCII data to the given type
@@ -41,16 +31,12 @@ namespace boost{namespace astronomy{namespace io{
         */
         template<typename T>
         static T deserialize_to(const std::string& convert_str, int) {
-
-            T converted_value;
-            auto iter_pos = convert_str.begin();
-            boost::spirit::qi::parse(iter_pos, convert_str.end(), spirit_type(boost::type<T>()), converted_value);
-            if (iter_pos != convert_str.end()) {
-
+            try {
+                return boost::lexical_cast<T>(convert_str);
+            }
+            catch (bad_lexical_cast&) {
                 throw invalid_cast("Cannot convert from String to the required Type");
             }
-
-            return converted_value;
         }
 
         /**
@@ -59,7 +45,7 @@ namespace boost{namespace astronomy{namespace io{
          * @tparam T Type of value which needs to be serialized
         */
         template<typename T>
-       static std::string serialize(T value) {
+        static std::string serialize(T value) {
             // Default for now future versions should use overloads for better performance
             std::stringstream serialize_stream;
             serialize_stream << value;
@@ -67,6 +53,7 @@ namespace boost{namespace astronomy{namespace io{
         }
 
     };
+
 
 } } }
 


### PR DESCRIPTION
Boost. Spirit framework did not provide any considerable performance difference when compared to lexical cast. Not only did spirit increase the maintenance overhead, inclusion of spirit headers caused the Intellisense( in vs) to include about 43000 additional files. This was causing the Intellisense  to lag ( The same might be experienced in other IDE's with code completion features ). Also after inclusion of fits.hpp header in a separate MS build project, it was observed that the IDE transitioned itself into a Non-Responding state for about 10 seconds.

This surely hurts the programmers experience with our library. Hence the Spirit was replaced with lexical cast based converter in order to remove lag and provide quick intellisense. 

**One thing to note especially is that if the user still prefers to use spirit or some other converter framework then the user can do so by obeying the compile time interface of ascii_converter and  plugging into card policy or ascii table class**