### PR TITLE
Implemented own Julian date due to ambiguity and corrected time tests

### DIFF
--- a/include/boost/astronomy/time/time_conversions.hpp
+++ b/include/boost/astronomy/time/time_conversions.hpp
@@ -127,7 +127,7 @@ decimal_hour GST(ptime t)
 enum class DIRECTION {WEST, EAST};
 
 //Local Sidereal Time (LST)
-decimal_hour LST(long double longitude, DIRECTION direction, ptime t)
+decimal_hour LST(double longitude, DIRECTION direction, ptime t)
 {
     double gst = GST(t).get();
 

--- a/include/boost/astronomy/time/time_conversions.hpp
+++ b/include/boost/astronomy/time/time_conversions.hpp
@@ -30,7 +30,7 @@ namespace boost { namespace astronomy { namespace time {
  * made on the Greenwich meridian, longitude 0◦.
  */
 
-double Julian_date(boost::posix_time::ptime t)
+double julian_date(boost::posix_time::ptime t)
 {
     //Get date from UT
     boost::gregorian::date dt = t.date();
@@ -92,7 +92,7 @@ double Julian_date(boost::posix_time::ptime t)
 decimal_hour GST(boost::posix_time::ptime t)
 {
     //Get Julian Day Number
-    double JD = Julian_date(t);
+    double JD = julian_date(t);
 
     double S = JD - 2451545.0;
 

--- a/include/boost/astronomy/time/time_conversions.hpp
+++ b/include/boost/astronomy/time/time_conversions.hpp
@@ -9,15 +9,12 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_ASTRONOMY_TIME_CONVERSIONS
 
 #include <string>
-#include <iostream>
 #include <exception>
 #include <boost/astronomy/time/parser.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-using namespace std;
-using namespace boost::gregorian;
-using namespace boost::posix_time;
+namespace boost { namespace astronomy { namespace time {
 
 /**
  * Universal time (UT), and therefore the local civil time in any
@@ -33,10 +30,10 @@ using namespace boost::posix_time;
  * made on the Greenwich meridian, longitude 0◦.
  */
 
-double Julian_date(ptime t)
+double Julian_date(boost::posix_time::ptime t)
 {
     //Get date from UT
-    date dt = t.date();
+    boost::gregorian::date dt = t.date();
 
     //Set y = year, m = month and d = day
     double y = dt.year();
@@ -59,7 +56,7 @@ double Julian_date(ptime t)
 
     //Calculate B, check if the date is later than 1582 October 15
     double B;
-    date dt1(1582, Oct , 1);
+    boost::gregorian::date dt1(1582, boost::gregorian::Oct , 1);
     if ( dt > dt1 )
     {
         double A = floor(yprime / 100);
@@ -92,10 +89,10 @@ double Julian_date(ptime t)
     return JD;
 }
 
-decimal_hour GST(ptime t)
+decimal_hour GST(boost::posix_time::ptime t)
 {
     //Get date from UT
-    date d = t.date();
+    boost::gregorian::date d = t.date();
 
     //Get Julian Day Number
     double JD = Julian_date(t);
@@ -127,7 +124,7 @@ decimal_hour GST(ptime t)
 enum class DIRECTION {WEST, EAST};
 
 //Local Sidereal Time (LST)
-decimal_hour LST(double longitude, DIRECTION direction, ptime t)
+decimal_hour LST(double longitude, DIRECTION direction, boost::posix_time::ptime t)
 {
     double gst = GST(t).get();
 
@@ -158,4 +155,5 @@ decimal_hour LST(double longitude, DIRECTION direction, ptime t)
     return {long_hours};
 }
 
+}}} // namespace::astronomy::time
 #endif //BOOST_ASTRONOMY_TIME_CONVERSIONS

--- a/include/boost/astronomy/time/time_conversions.hpp
+++ b/include/boost/astronomy/time/time_conversions.hpp
@@ -98,7 +98,7 @@ decimal_hour GST(ptime t)
     date d = t.date();
 
     //Get Julian Day Number
-    double JD = Julian_date(t); //Ambiguity in Julian precision.
+    double JD = Julian_date(t);
 
     double S = JD - 2451545.0;
 

--- a/include/boost/astronomy/time/time_conversions.hpp
+++ b/include/boost/astronomy/time/time_conversions.hpp
@@ -91,9 +91,6 @@ double Julian_date(boost::posix_time::ptime t)
 
 decimal_hour GST(boost::posix_time::ptime t)
 {
-    //Get date from UT
-    boost::gregorian::date d = t.date();
-
     //Get Julian Day Number
     double JD = Julian_date(t);
 

--- a/test/coordinate/utility.cpp
+++ b/test/coordinate/utility.cpp
@@ -7,7 +7,6 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_TEST_MODULE utility
 
-#include <iostream>
 #include <boost/units/io.hpp>
 #include <boost/units/systems/angle/degrees.hpp>
 
@@ -31,6 +30,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 using namespace boost::units;
 using namespace boost::units::si;
 using namespace boost::astronomy::coordinate;
+using namespace boost::astronomy::time;
 
 namespace bud = boost::units::degree;
 namespace bac = boost::astronomy::coordinate;

--- a/test/time/time_conversions.cpp
+++ b/test/time/time_conversions.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(time)
   //when the GST is 4h 40m 5.23s OR
   //at 14h 36m 51.67s UT on Greenwich date 22 April 1980
   //Local Sidereal Time at Longitude 64.00°(W) = 0h 24m 5.23s
-  decimal_hour d2 = LST(64,DIRECTION::WEST, decimal_hour(4,40,5.23).get());
+  decimal_hour d2 = LST(64, DIRECTION::WEST, t1);
 
   BOOST_CHECK_CLOSE(d2.get(), decimal_hour(0,24,5.23).get(), 1);
 
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(time)
   //when the GST is 8h 36m 55.00s OR
   //at 19h 21m 0.00s UT on Greenwich date 10 April 1987
   //Local Sidereal Time at Longitude 82.00° (E) = 14h 05m 42s
-  decimal_hour d4 = LST(82, DIRECTION::EAST, decimal_hour(8,34,57.0896).get());
+  decimal_hour d4 = LST(82, DIRECTION::EAST, t2);
 
   BOOST_CHECK_CLOSE(d4.get(), decimal_hour(14,5,42).get(), 1);
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(time)
   //when the GST is 14h 14m 18.136s OR
   //at at 16h 44m 0.0s UT on Greenwich date 13 August 2020
   //Local Sidereal Time at Longitude 37.00° (E) = 16h 42m 19s
-  decimal_hour d6 = LST(37, DIRECTION::EAST, decimal_hour(14, 14, 18.136).get());
+  decimal_hour d6 = LST(37, DIRECTION::EAST, t3);
 
   BOOST_CHECK_CLOSE(d6.get(), decimal_hour(16, 42, 19).get(), 1);
 }

--- a/test/time/time_conversions.cpp
+++ b/test/time/time_conversions.cpp
@@ -14,6 +14,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>
 
+using namespace boost::astronomy::time;
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_SUITE(time_conversions)
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(time)
   //Verified from Practical Astronomy with your Calculator
   //by Peter Duffett-Smith
   std::string ts1("1980-04-22 14:36:51.67");
-  ptime t1(time_from_string(ts1));
+  boost::posix_time::ptime t1(boost::posix_time::time_from_string(ts1));
 
   decimal_hour d1 = GST(t1);
 
@@ -44,7 +45,7 @@ BOOST_AUTO_TEST_CASE(time)
   //GST = 8h 34m 57.0896s
   //Verified from Astronomical Algorithms 2nd Edition. by. Jean Meeus
   std::string ts2("1987-04-10 19:21:0");
-  ptime t2(time_from_string(ts2));
+  boost::posix_time::ptime t2(boost::posix_time::time_from_string(ts2));
 
   decimal_hour d3 = GST(t2);
 
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(time)
   //GST = 14h 14m 18.136s
   //Verified from http://neoprogrammics.com/sidereal_time_calculator/index.php
   std::string ts3("2020-08-13 16:44:0");
-  ptime t3(time_from_string(ts3));
+  boost::posix_time::ptime t3(boost::posix_time::time_from_string(ts3));
 
   decimal_hour d5 = GST(t3);
 


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

The tests have been corrected, as there was a mismatch in the types.
There is an ambiguity in the precision of the Julian date of ptime, so I have implemented Julian date of my own.
By running locally, I could see a huge accuracy by doing so.

### References

I have referred the page number 33/240 of the book - Practical Astronomy with your Calculator or Spreadsheet, 4th edition

