### PR TITLE
Added vector header to prevent build faliure in GCC and Clang builds

### DIFF
--- a/include/boost/astronomy/io/default_card_policy.hpp
+++ b/include/boost/astronomy/io/default_card_policy.hpp
@@ -9,6 +9,7 @@ file License.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 #ifndef BOOST_ASTRONOMY_DEFAULT_CARD_POLICY_HPP
 #define BOOST_ASTRONOMY_DEFAULT_CARD_POLICY_HPP
 
+#include <vector>
 #include <map>
 #include <algorithm>
 #include <sstream>


### PR DESCRIPTION
### Description

Added vector header in default_card_policy.hpp to remove the build failures caused in current GCC and Clang builds