### PR TITLE
Corrected atan2 expression

### DIFF
--- a/include/boost/astronomy/coordinate/sky_point.hpp
+++ b/include/boost/astronomy/coordinate/sky_point.hpp
@@ -132,7 +132,7 @@ public:
             coslat * std::sin(temp_p1) * std::cos(temp_diff);
         double y = std::sin(temp_diff) * coslat;
 
-        return bu::quantity<bu::si::plane_angle>::from_value(std::atan2(x, y));
+        return bu::quantity<bu::si::plane_angle>::from_value(std::atan2(y, x));
     }
 
     //!returns true if both coordinate systems are same else returns false


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Corrected the expression of positional angle. At the end, it should be atan2(y,x) instead of atan2(x,y).

### References

https://en.wikipedia.org/wiki/Position_angle
![image](https://user-images.githubusercontent.com/54735797/103189273-e4ed3080-48f1-11eb-88f4-2cc1ea964ced.png)

