### PR TITLE
Correct bg::point to coslat differential conversion

### DIFF
--- a/include/boost/astronomy/coordinate/diff/spherical_coslat_differential.hpp
+++ b/include/boost/astronomy/coordinate/diff/spherical_coslat_differential.hpp
@@ -427,13 +427,18 @@ make_spherical_coslat_differential
     > const& pointObject
 )
 {
+    bg::model::point<OtherCoordinateType, 3, bg::cs::spherical<radian>> temp;
+    bg::transform(pointObject, temp);
+
+    bg::set<1>(temp, bg::get<1>(temp) * cos(bg::get<0>(temp)));
+
     return spherical_coslat_differential
         <
             CoordinateType,
             LatQuantity,
             LonQuantity,
             DistQuantity
-        >(pointObject);
+        >(temp);
 }
 
 //!constructs object from any type of differential


### PR DESCRIPTION
<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

Resolves issue #185 
The longitude has been multiplied with cos(latitude), where latitude is in radian
